### PR TITLE
Bug Fix - Change time back to a string

### DIFF
--- a/src/components/timer-panel.jsx
+++ b/src/components/timer-panel.jsx
@@ -16,23 +16,12 @@ TimerPanel.propTypes = {
   id: PropTypes.number,
   onDeleteTimer: PropTypes.func,
   timerName: PropTypes.string,
-  submittedTime: PropTypes.number,
+  submittedTime: PropTypes.string,
   onTimerSubmit: PropTypes.func,
   onTimerNameChange: PropTypes.func,
 };
 
 export default function TimerPanel(props) {
-  const ALARM_SOUND = new Audio(alarmFile);
-
-  const [isStarted, setIsStarted] = useState(false);
-  const [time, setTime] = useState(props.submittedTime);
-  const [timeError, setTimeError] = useState("");
-
-  useEffect(() => {
-    console.log(props.submittedTime);
-    setTime(props.submittedTime);
-  }, [props.submittedTime]);
-
   const translateTimeToSeconds = (input) => {
     const [hoursString, minutesString, secondsString] = input.split(":");
     const hours = +hoursString;
@@ -41,7 +30,7 @@ export default function TimerPanel(props) {
     return hours * 60 * 60 + minutes * 60 + seconds;
   };
 
-  const renderTimeInReadableFormat = (input) => {
+  const translateSecondsToTime = (input) => {
     const hours = Math.floor(input / (60 * 60));
     const minutes = Math.floor((input % (60 * 60)) / 60);
     const seconds = input % 60;
@@ -54,11 +43,24 @@ export default function TimerPanel(props) {
     );
   };
 
+  const ALARM_SOUND = new Audio(alarmFile);
+
+  const [isStarted, setIsStarted] = useState(false);
+  const [time, setTime] = useState(props.submittedTime);
+  const [timeInSeconds, setTimeInSeconds] = useState(
+    translateTimeToSeconds(props.submittedTime)
+  );
+  const [timeError, setTimeError] = useState("");
+
+  useEffect(() => {
+    setTime(props.submittedTime);
+  }, [props.submittedTime]);
+
   useEffect(() => {
     let interval;
     if (isStarted) {
       interval = setInterval(() => {
-        setTime((prevTime) => {
+        setTimeInSeconds((prevTime) => {
           if (prevTime === 0) {
             clearInterval(interval);
             restartTimer();
@@ -87,11 +89,11 @@ export default function TimerPanel(props) {
   };
 
   const handleTimeChange = (event) => {
-    setTime(translateTimeToSeconds(event.currentTarget.value));
+    setTime(event.currentTarget.value);
   };
 
   const checkTime = () => {
-    if (time > 0) {
+    if (time && translateTimeToSeconds(time) > 0) {
       setTimeError("");
       return true;
     } else {
@@ -115,6 +117,7 @@ export default function TimerPanel(props) {
       return;
     } else {
       submitTime();
+      setTimeInSeconds(translateTimeToSeconds(time));
       setIsStarted(true);
     }
   };
@@ -136,7 +139,7 @@ export default function TimerPanel(props) {
         <TimeInput
           error={timeError}
           onChange={handleTimeChange}
-          value={renderTimeInReadableFormat(time)}
+          value={isStarted ? translateSecondsToTime(timeInSeconds) : time}
           withSeconds
           disabled={isStarted}
           onBlur={submitTime}

--- a/src/components/timer-panel.jsx
+++ b/src/components/timer-panel.jsx
@@ -17,7 +17,7 @@ TimerPanel.propTypes = {
   onDeleteTimer: PropTypes.func,
   timerName: PropTypes.string,
   submittedTime: PropTypes.number,
-  onTimerStart: PropTypes.func,
+  onTimerSubmit: PropTypes.func,
   onTimerNameChange: PropTypes.func,
 };
 
@@ -27,6 +27,11 @@ export default function TimerPanel(props) {
   const [isStarted, setIsStarted] = useState(false);
   const [time, setTime] = useState(props.submittedTime);
   const [timeError, setTimeError] = useState("");
+
+  useEffect(() => {
+    console.log(props.submittedTime);
+    setTime(props.submittedTime);
+  }, [props.submittedTime]);
 
   const translateTimeToSeconds = (input) => {
     const [hoursString, minutesString, secondsString] = input.split(":");
@@ -95,13 +100,21 @@ export default function TimerPanel(props) {
     }
   };
 
+  const submitTime = () => {
+    if (!checkTime()) {
+      return;
+    } else {
+      props.onTimerSubmit(props.id, time);
+    }
+  };
+
   const toggleTimer = () => {
     if (isStarted) {
       setIsStarted(false);
     } else if (!checkTime()) {
       return;
     } else {
-      props.onTimerStart(props.id, time);
+      submitTime();
       setIsStarted(true);
     }
   };
@@ -126,7 +139,7 @@ export default function TimerPanel(props) {
           value={renderTimeInReadableFormat(time)}
           withSeconds
           disabled={isStarted}
-          onBlur={checkTime}
+          onBlur={submitTime}
         />
         <p />
         <Group>

--- a/src/components/timers-group.jsx
+++ b/src/components/timers-group.jsx
@@ -1,22 +1,14 @@
 import * as React from "react";
 import { useState, useReducer } from "react";
-import {
-  Button,
-  Grid,
-  Space,
-  TextInput,
-  Fieldset,
-  Notification,
-} from "@mantine/core";
+import { Button, Grid, Space, TextInput, Fieldset } from "@mantine/core";
 import TimerPanel from "./timer-panel.jsx";
-import { IconCheck, IconPlus, IconX } from "@tabler/icons-react";
+import { IconPlus } from "@tabler/icons-react";
 import timersReducer from "../reducers/timers-reducer.js";
 import { initialTimers } from "../reducers/timers-reducer.js";
 import {
   loadTimersFromFile,
   storeTimersToFile,
 } from "../helpers/timers-writer.js";
-import buttonClasses from "../css/button.module.css";
 import SuccessNotification from "./success-notification.jsx";
 
 // TODO: need to make new groups
@@ -58,7 +50,7 @@ export default function TimersGroup() {
           id={id}
           timerName={timerName}
           submittedTime={submittedTime}
-          onTimerStart={saveSubmittedTime}
+          onTimerSubmit={saveSubmittedTime}
           onTimerNameChange={saveTimerName}
         />
       </Grid.Col>
@@ -111,11 +103,6 @@ export default function TimersGroup() {
 
   return (
     <React.Fragment>
-      <SuccessNotification
-        successful={successNotification.successful}
-        showNotification={successNotification.showNotification}
-        successfulText={successNotification.successfulText}
-      />
       <Button onClick={saveTimers}>Save Timers</Button>
       <Button onClick={loadTimers}>Load Timers</Button>
 
@@ -140,6 +127,11 @@ export default function TimersGroup() {
           </Button>
         </Grid>
       </Fieldset>
+      <SuccessNotification
+        successful={successNotification.successful}
+        showNotification={successNotification.showNotification}
+        successfulText={successNotification.successfulText}
+      />
     </React.Fragment>
   );
 }

--- a/src/preload.js
+++ b/src/preload.js
@@ -7,6 +7,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.send("show-notification", title, body),
   saveTimersToFile: (filePath, fileName, body) =>
     ipcRenderer.invoke("save-timers-to-file", filePath, fileName, body),
-  loadTimersFromFile: (filePath, fileName, body) =>
+  loadTimersFromFile: (filePath, fileName) =>
     ipcRenderer.invoke("load-timers-from-file", filePath, fileName),
 });

--- a/src/reducers/timers-reducer.js
+++ b/src/reducers/timers-reducer.js
@@ -25,7 +25,7 @@ const createDefaultTimerConfig = (id) => {
   return {
     id,
     timerName: "Timer Name",
-    submittedTime: 0,
+    submittedTime: "00:00:00",
   };
 };
 


### PR DESCRIPTION
Still not sure how I feel about this...but it does fix a couple bugs and is technically fewer computations.
I might just make my own TimeInput component. Eventually.

Goal:
- reduce the amount of translating back and forth between the `string` representation that Mantine's `TimeInput` component takes in, and the numerical representation used to count down
  - Change: added a `timeInSeconds` state that only gets set when Start is toggled
  - Change: changes `time` back into a `string`
  - Change: `value` of the `TimeInput` is a ternary -- if the timer is started, then display the translated `timeInSeconds`. Otherwise
- fix the bug where you couldn't input 01:00:00 because the translation would get in the way
  - Changing `time` to a `string` resolved this
- more realtime value for Save Timers 
  - Change: `onBlur()` also will send the userInput time to the parent as `submittedTime` (if the input is valid)
